### PR TITLE
fix issue where cell image is incorrect

### DIFF
--- a/OHQBImagePicker/QBAssetsViewController.m
+++ b/OHQBImagePicker/QBAssetsViewController.m
@@ -388,10 +388,13 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
 	CGSize itemSize = [(UICollectionViewFlowLayout *)self.collectionView.collectionViewLayout itemSize];
 	CGSize targetSize = CGSizeScale(itemSize, [[UIScreen mainScreen] scale]);
 	
+	PHImageRequestOptions *options = [PHImageRequestOptions new];
+	options.synchronous = YES;
+
 	[self.imageManager requestImageForAsset:asset
 								 targetSize:targetSize
 								contentMode:PHImageContentModeAspectFill
-									options:nil
+									options:options
 							  resultHandler:^(UIImage *result, NSDictionary *info) {
 								  if (cell.tag == indexPath.row) {
 									  cell.imageView.image = result;


### PR DESCRIPTION
Because the images for QBItemCell instances are loaded asynchronously,
the imageView.image could be set after the cell has already been
dequeued for re-use. This would cause the thumbnail to be incorrect
and the image chosen by tapping it would be a different image.

By making the code wait until the image is retrieved, we ensure that the
cell's imageView.image has the correct image.