### PR TITLE
Rename umbrella header so the compiled framework creates a module.map that can be used directly from Swift

### DIFF
--- a/OHQBImagePicker.xcodeproj/project.pbxproj
+++ b/OHQBImagePicker.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		AA3AD0701ACF9A3A00BF523E /* QBVideoIconView.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3AD06E1ACF9A3A00BF523E /* QBVideoIconView.m */; };
 		AA3AD0731ACFA06700BF523E /* QBVideoIndicatorView.h in Headers */ = {isa = PBXBuildFile; fileRef = AA3AD0711ACFA06700BF523E /* QBVideoIndicatorView.h */; };
 		AA3AD0741ACFA06700BF523E /* QBVideoIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3AD0721ACFA06700BF523E /* QBVideoIndicatorView.m */; };
-		AAA8FE091ACDA079002A9710 /* QBImagePicker.h in Headers */ = {isa = PBXBuildFile; fileRef = AAA8FE081ACDA079002A9710 /* QBImagePicker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AAA8FE091ACDA079002A9710 /* OHQBImagePicker.h in Headers */ = {isa = PBXBuildFile; fileRef = AAA8FE081ACDA079002A9710 /* OHQBImagePicker.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AAA8FE0F1ACDA079002A9710 /* OHQBImagePicker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAA8FE031ACDA079002A9710 /* OHQBImagePicker.framework */; };
 		AAA8FE161ACDA079002A9710 /* QBImagePickerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AAA8FE151ACDA079002A9710 /* QBImagePickerTests.m */; };
 		AAA8FE211ACDA090002A9710 /* QBImagePickerController.h in Headers */ = {isa = PBXBuildFile; fileRef = AAA8FE1F1ACDA090002A9710 /* QBImagePickerController.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -96,7 +96,7 @@
 		AA3AD0721ACFA06700BF523E /* QBVideoIndicatorView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = QBVideoIndicatorView.m; sourceTree = "<group>"; };
 		AAA8FE031ACDA079002A9710 /* OHQBImagePicker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OHQBImagePicker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAA8FE071ACDA079002A9710 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		AAA8FE081ACDA079002A9710 /* QBImagePicker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QBImagePicker.h; sourceTree = "<group>"; };
+		AAA8FE081ACDA079002A9710 /* OHQBImagePicker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OHQBImagePicker.h; sourceTree = "<group>"; };
 		AAA8FE0E1ACDA079002A9710 /* OHQBImagePickerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OHQBImagePickerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAA8FE141ACDA079002A9710 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AAA8FE151ACDA079002A9710 /* QBImagePickerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QBImagePickerTests.m; sourceTree = "<group>"; };
@@ -225,7 +225,7 @@
 		AAA8FE051ACDA079002A9710 /* OHQBImagePicker */ = {
 			isa = PBXGroup;
 			children = (
-				AAA8FE081ACDA079002A9710 /* QBImagePicker.h */,
+				AAA8FE081ACDA079002A9710 /* OHQBImagePicker.h */,
 				AA3AD0751ACFA22500BF523E /* Views */,
 				AA3AD0761ACFA23300BF523E /* ViewControllers */,
 				AAF1CA241ACE5665005F6295 /* Resources */,
@@ -336,7 +336,7 @@
 				AAF1CA1A1ACE5467005F6295 /* QBAlbumCell.h in Headers */,
 				AAA8FE5B1ACDA554002A9710 /* QBAlbumsViewController.h in Headers */,
 				AA3AD06F1ACF9A3A00BF523E /* QBVideoIconView.h in Headers */,
-				AAA8FE091ACDA079002A9710 /* QBImagePicker.h in Headers */,
+				AAA8FE091ACDA079002A9710 /* OHQBImagePicker.h in Headers */,
 				AABBF0901ACEDDFF003188A3 /* QBCheckmarkView.h in Headers */,
 				AAA8FE211ACDA090002A9710 /* QBImagePickerController.h in Headers */,
 			);
@@ -705,7 +705,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.questbeat.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -721,7 +721,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.questbeat.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};

--- a/OHQBImagePicker/OHQBImagePicker.h
+++ b/OHQBImagePicker/OHQBImagePicker.h
@@ -1,5 +1,5 @@
 //
-//  QBImagePicker.h
+//  OHQBImagePicker.h
 //  QBImagePicker
 //
 //  Created by Katsuma Tanaka on 2015/04/03.

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ A clone of UIImagePickerController with multiple selection support.
 
 1. Add `pod "OHQBImagePicker"` to Podfile
 2. Run `pod install`
-3. Add `#import <OHQBImagePicker/QBImagePicker.h>` to your code
+3. Add `#import <OHQBImagePicker/OHQBImagePicker.h>` to your ObjC code or `import OHQBImagePicker` to your Swift code.
 
 
 ### Carthage
 
 1. Add `github "questbeat/QBImagePicker"` to Cartfile
 2. Run `carthage update`
-3. Add `#import <OHQBImagePicker/QBImagePicker.h>` to your code
+3. Add `#import <OHQBImagePicker/OHQBImagePicker.h>` to your ObjC code or `import OHQBImagePicker` to your Swift code.
 
 
 


### PR DESCRIPTION
The current build product doesn't create a `Modules/module.modulemap` inside the framework:

<img width="300" alt="screen shot 2018-08-03 at 12 44 56 pm" src="https://user-images.githubusercontent.com/2429905/43640419-30d9c106-9720-11e8-8002-960b5a7a9d65.png">

This prevents OHQBImagePicker from being imported as a module in ObjC with `@import OHQBImagePicker` or in Swift as `import OHQBImagePicker` and forces to import `<OHQBImagePicker/QBImagePicker.h>` on an bridging-header in order to use it in Swift. That doesn't work if the code is inside a modular framework, as the import will have to be in the umbrella header and `<OHQBImagePicker/QBImagePicker.h>` is not a modular header, so it will give a compilation error about "non-modular headers" being imported.

By just renaming `QBImagePicker.h` to `OHQBImagePicker.h`, as the project is configured with `Defines module` as `YES` Xcode will automatically create a `module.modulemap`:

<img width="597" alt="screen shot 2018-08-03 at 12 41 45 pm" src="https://user-images.githubusercontent.com/2429905/43640429-387e5bf6-9720-11e8-837e-86b78107c96d.png">

